### PR TITLE
XOA quick deploy: warn when XOA IP is same as host IP

### DIFF
--- a/SOURCES/0001-fix-XOA-deploy-dont-fail-on-missing-XenStore-entries.patch
+++ b/SOURCES/0001-fix-XOA-deploy-dont-fail-on-missing-XenStore-entries.patch
@@ -1,7 +1,7 @@
 From 93c3f1b5a2efd5871e53705daedbb67642150c44 Mon Sep 17 00:00:00 2001
 From: Julien Fontanet <julien.fontanet@isonoe.net>
 Date: Wed, 2 Jun 2021 17:10:22 +0200
-Subject: [PATCH 1/4] fix(XOA deploy): dont fail on missing XenStore entries
+Subject: [PATCH 1/5] fix(XOA deploy): dont fail on missing XenStore entries
 
 May fix https://twitter.com/cqchu/status/1396769270537785344
 

--- a/SOURCES/0002-feat-XOA-deploy-account-disabled-if-no-password-set.patch
+++ b/SOURCES/0002-feat-XOA-deploy-account-disabled-if-no-password-set.patch
@@ -1,7 +1,7 @@
 From ecf59c775022a8fe862aa8282fd45af13ba42149 Mon Sep 17 00:00:00 2001
 From: Julien Fontanet <julien.fontanet@isonoe.net>
 Date: Wed, 2 Jun 2021 17:23:49 +0200
-Subject: [PATCH 2/4] feat(XOA deploy): account disabled if no password set
+Subject: [PATCH 2/5] feat(XOA deploy): account disabled if no password set
 
 Signed-off-by: Julien Fontanet <julien.fontanet@isonoe.net>
 ---

--- a/SOURCES/0003-chore-landing-page-update-JQuery-from-3.3.1-to-3.6.0.patch
+++ b/SOURCES/0003-chore-landing-page-update-JQuery-from-3.3.1-to-3.6.0.patch
@@ -1,7 +1,7 @@
 From 26fe0446854cb9d4e724c07620588f268d4f645e Mon Sep 17 00:00:00 2001
 From: Pierre Donias <pierre.donias@gmail.com>
 Date: Wed, 8 Sep 2021 14:48:40 +0200
-Subject: [PATCH 3/4] chore(landing page): update JQuery from 3.3.1 to 3.6.0
+Subject: [PATCH 3/5] chore(landing page): update JQuery from 3.3.1 to 3.6.0
  (#21)
 
 See https://xcp-ng.org/forum/topic/4875

--- a/SOURCES/0004-Improve-clarity-by-avoiding-XOA-acronym-alone.-22.patch
+++ b/SOURCES/0004-Improve-clarity-by-avoiding-XOA-acronym-alone.-22.patch
@@ -1,7 +1,7 @@
 From 10d91dcd7560c9ee6588b90ba3efaf50ab85fe51 Mon Sep 17 00:00:00 2001
 From: Olivier Lambert <olivier.lambert@vates.fr>
 Date: Wed, 8 Sep 2021 14:50:11 +0200
-Subject: [PATCH 4/4] Improve clarity by avoiding "XOA" acronym alone. (#22)
+Subject: [PATCH 4/5] Improve clarity by avoiding "XOA" acronym alone. (#22)
 
 Signed-off-by: Olivier Lambert <olivier.lambert@vates.fr>
 ---

--- a/SOURCES/0005-feat-XOA-deploy-warning-when-XOA-IP-is-the-same-as-h.patch
+++ b/SOURCES/0005-feat-XOA-deploy-warning-when-XOA-IP-is-the-same-as-h.patch
@@ -1,0 +1,92 @@
+From 28204237fd4bb58b478c4a6915f2d009727b45df Mon Sep 17 00:00:00 2001
+From: Pierre Donias <pierre.donias@gmail.com>
+Date: Mon, 29 Nov 2021 15:13:15 +0100
+Subject: [PATCH 5/5] feat(XOA deploy): warning when XOA IP is the same as host
+ IP
+
+Signed-off-by: Pierre Donias <pierre.donias@gmail.com>
+---
+ src/xenserver/opt/xensource/www/XCP-ng-index.html | 15 ++++++++++++++-
+ src/xenserver/opt/xensource/www/asset/deploy.js   | 11 +++++++++++
+ .../asset/fontawesome-pro-5.8.1-web/css/all.css   |  3 +++
+ 3 files changed, 28 insertions(+), 1 deletion(-)
+
+diff --git a/src/xenserver/opt/xensource/www/XCP-ng-index.html b/src/xenserver/opt/xensource/www/XCP-ng-index.html
+index 03930e9..c710946 100644
+--- a/src/xenserver/opt/xensource/www/XCP-ng-index.html
++++ b/src/xenserver/opt/xensource/www/XCP-ng-index.html
+@@ -41,6 +41,10 @@
+         margin: 0 auto;
+       }
+ 
++      .danger {
++        color: #d9534f;
++      }
++
+       p {
+         text-align: center;
+         padding: 0.5em 1em;
+@@ -475,7 +479,7 @@
+         </form>
+         <form
+           id="config"
+-          onsubmit="event.preventDefault(); setStep('config', 'accounts')"
++          onsubmit="event.preventDefault(); submitConfig()"
+           style="display: none"
+         >
+           <fieldset>
+@@ -491,6 +495,15 @@
+                 <select id="networks"></select>
+               </label>
+             </p>
++            <p id="ip-error" style="display: none">
++              <em class="danger"
++                ><i class="fas fa-exclamation-triangle"></i>
++                <span
++                  >You entered the same IP address as your host. Please choose a
++                  different one for your XOA:</span
++                ></em
++              >
++            </p>
+             <p>
+               <label>
+                 XOA VM IP address<br />
+diff --git a/src/xenserver/opt/xensource/www/asset/deploy.js b/src/xenserver/opt/xensource/www/asset/deploy.js
+index ad9faa7..081fd88 100644
+--- a/src/xenserver/opt/xensource/www/asset/deploy.js
++++ b/src/xenserver/opt/xensource/www/asset/deploy.js
+@@ -121,6 +121,17 @@ function connect() {
+     })
+ }
+ 
++function submitConfig() {
++  const ipError = $('#ip-error')
++  ipError.hide()
++  const ip = $('#ip').val()
++  if (ip === window.location.hostname) {
++    ipError.show()
++    return
++  }
++  setStep('config', 'accounts')
++}
++
+ function deploy() {
+   const status = text => $('#deploy').text(text)
+   $('i.fa-spinner.fa-pulse').css({ display: 'inherit' })
+diff --git a/src/xenserver/opt/xensource/www/asset/fontawesome-pro-5.8.1-web/css/all.css b/src/xenserver/opt/xensource/www/asset/fontawesome-pro-5.8.1-web/css/all.css
+index 535b638..fd35422 100644
+--- a/src/xenserver/opt/xensource/www/asset/fontawesome-pro-5.8.1-web/css/all.css
++++ b/src/xenserver/opt/xensource/www/asset/fontawesome-pro-5.8.1-web/css/all.css
+@@ -185,6 +185,9 @@ readers do not read off random characters that represent icons */
+ .fa-browser:before {
+   content: "\f37e"; }
+ 
++.fa-exclamation-triangle:before {
++  content: "\f071"; }
++
+ .fa-github:before {
+   content: "\f09b"; }
+ 
+-- 
+2.30.2
+

--- a/SPECS/xcp-ng-release.spec
+++ b/SPECS/xcp-ng-release.spec
@@ -24,7 +24,7 @@
 
 Name:           xcp-ng-release
 Version:        8.2.0
-Release:        7
+Release:        8
 Summary:        XCP-ng release file
 Group:          System Environment/Base
 License:        GPLv2
@@ -80,6 +80,7 @@ Patch1: 0001-fix-XOA-deploy-dont-fail-on-missing-XenStore-entries.patch
 Patch2: 0002-feat-XOA-deploy-account-disabled-if-no-password-set.patch
 Patch3: 0003-chore-landing-page-update-JQuery-from-3.3.1-to-3.6.0.patch
 Patch4: 0004-Improve-clarity-by-avoiding-XOA-acronym-alone.-22.patch
+Patch5: 0005-feat-XOA-deploy-warning-when-XOA-IP-is-the-same-as-h.patch
 
 %description
 XCP-ng release files
@@ -733,6 +734,9 @@ systemctl preset-all --preset-mode=enable-only || :
 
 # Keep this changelog through future updates
 %changelog
+* Thu Dec 02 2021 Samuel Verschelde <stormi-xcp@ylix.fr> - 8.2.0-8
+- XOA quick deploy: warn when XOA IP is same as host IP
+
 * Fri Sep 10 2021 Samuel Verschelde <stormi-xcp@ylix.fr> - 8.2.0-7
 - Don't reenable rsyslog.service when not needed
 - Landing page: XOA deploy fixes


### PR DESCRIPTION
Patch 0005-feat-XOA-deploy-warning-when-XOA-IP-is-the-same-as-h.patch
added from [source repository](https://github.com/xcp-ng/xcp-ng-release/tree/8.2).