### PR TITLE
Revert "Stop using /etc/motd.xs" (and update release and changelog)

### DIFF
--- a/SPECS/xcp-ng-release.spec
+++ b/SPECS/xcp-ng-release.spec
@@ -39,7 +39,7 @@
 
 Name:           xcp-ng-release
 Version:        8.3.0
-Release:        5
+Release:        6
 Summary:        XCP-ng release file
 Group:          System Environment/Base
 License:        GPLv2
@@ -466,16 +466,15 @@ EOF
 %triggerin config -- tzdata
 ln -f %{_datadir}/zoneinfo/Asia/Shanghai %{_datadir}/zoneinfo/Asia/Beijing
 
-# XCP-ng: since 8.3beta, undo this modification made in previous releases
 %triggerin config -- shadow-utils
 ( patch -tsN -r - -d / -p1 || : ) >/dev/null <<'EOF'
 --- /etc/login.defs.orig    2016-02-26 11:11:20.000000000 +0000
 +++ /etc/login.defs 2016-02-26 11:11:57.000000000 +0000
-@@ -70,4 +70,3 @@
+@@ -70,3 +70,4 @@
  # Use SHA512 to encrypt password.
  ENCRYPT_METHOD SHA512
 
--MOTD_FILE /etc/motd.xs
++MOTD_FILE /etc/motd.xs
 EOF
 
 %triggerin config -- yum
@@ -708,6 +707,9 @@ systemctl preset-all --preset-mode=enable-only || :
 
 # Keep this changelog through future updates
 %changelog
+* Thu Jan 05 2023 Samuel Verschelde <stormi-xcp@ylix.fr> - 8.3.0-6
+- Revert previous change: we'll fix the contents of the file instead
+
 * Thu Dec 22 2022 Yann Dirson <yann.dirson@vates.fr> - 8.3.0-5
 - Stop using /etc/motd.xs and modifying /etc/login.defs; try undo modification on upgrade
 


### PR DESCRIPTION
This somewhat reverts commit e02704d203782df0d7b84e2430ad0f831798871b.

This is not an exact git revert, as we still increase the Release tag, keep the previous changelog entry - the package got built in koji already - and add a new one.

Signed-off-by: Samuel Verschelde <stormi-xcp@ylix.fr>