### PR TITLE
Move depmod execution from '%post config' to '%posttrans config'

### DIFF
--- a/SPECS/xcp-ng-release.spec
+++ b/SPECS/xcp-ng-release.spec
@@ -552,6 +552,7 @@ then
     systemctl reenable rsyslog.service
 fi
 
+%posttrans config
 # We are shipping a file in depmod.d/, ensure it is used.
 # Note: if depmod is not present yet, no cache was created before we add
 # our config file, other packages will create it later, now with proper config.


### PR DESCRIPTION
When installing XCP-ng with kernel-alt, the kernel-alt package is installed after xcp-ng-release-config and the call to depmod in %post reports an error because kernel-alt modules are not installed yet. Moving the depmod call in %posttrans ensure the modules are present when executed.

This does not occur with main kernel because xcp-ng-release has a dependency on kernel-livepatch package so the main kernel is installed before xcp-ng-release.