### PR TITLE
Update .curlrc to fix TLS handshake

### DIFF
--- a/SOURCES/0001-fix-curl-resolve-TLS-issue-caused-by-restrictive-con.patch
+++ b/SOURCES/0001-fix-curl-resolve-TLS-issue-caused-by-restrictive-con.patch
@@ -1,0 +1,28 @@
+From e08c7d62ccf1acfedf0f227f1decd86110759c7d Mon Sep 17 00:00:00 2001
+From: Lucas RAVAGNIER <ravagnierlucas@gmail.com>
+Date: Tue, 14 Jan 2025 16:15:29 +0100
+Subject: [PATCH] fix(curl): resolve TLS issue caused by restrictive
+ configuration
+
+Using a `.curlrc` file restricts the use of openssl encryption.
+This restriction blocks the ability to deploy an XOA because
+`xoa.io` website requires newer certificates.
+This patch therefore aims to add the same encryption from the xoa.io,
+making deployment easier for users while maintaining secure communications.
+
+Signed-off-by: Lucas RAVAGNIER <ravagnierlucas@gmail.com>
+---
+ src/common/root/.curlrc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/common/root/.curlrc b/src/common/root/.curlrc
+index 46edee6..46ecb41 100644
+--- a/src/common/root/.curlrc
++++ b/src/common/root/.curlrc
+@@ -1,2 +1,2 @@
+-ciphers = ECDHE-RSA-AES256-SHA384,ECDHE-RSA-AES256-GCM-SHA384,AES256-SHA256,AES128-SHA256
++ciphers = ECDHE-RSA-AES256-SHA384,ECDHE-RSA-AES256-GCM-SHA384,AES256-SHA256,AES128-SHA256,ECDHE-ECDSA-AES128-GCM-SHA256
+ tlsv1.2
+-- 
+2.47.0
+

--- a/SPECS/xcp-ng-release.spec
+++ b/SPECS/xcp-ng-release.spec
@@ -45,7 +45,7 @@
 
 Name:           xcp-ng-release
 Version:        8.3.0
-Release:        28
+Release:        29
 Summary:        XCP-ng release file
 Group:          System Environment/Base
 License:        GPLv2
@@ -104,7 +104,7 @@ URL:            https://github.com/xcp-ng/xcp-ng-release
 Source0:        https://github.com/xcp-ng/xcp-ng-release/archive/v%{version}/xcp-ng-release-%{version}.tar.gz
 
 # XCP-ng Patches generated during maintenance period with `git format-patch v8.3`
-# (None at the moment)
+Patch1000: 0001-fix-curl-resolve-TLS-issue-caused-by-restrictive-con.patch
 
 %description
 XCP-ng release files
@@ -610,6 +610,10 @@ systemctl preset-all --preset-mode=enable-only || :
 
 # Keep this changelog through future updates
 %changelog
+* Mon Jan 20 2025 Lucas Ravagnier <lucas.ravagnier@vates.tech> - 8.3.0-29
+- Add 0001-fix-curl-resolve-TLS-issue-caused-by-restrictive-con.patch
+- This adds a cipher to '.curlrc' to fix a TLS Handshake Error with xoa.io
+
 * Fri Aug 23 2024 Samuel Verschelde <stormi-xcp@ylix.fr> - 8.3.0-28
 - Update repo files for CentOS and EPEL
 - Point at repo.vates.tech for CentOS since mirrorlist.centos.org was cut


### PR DESCRIPTION
Add a cipher in .curlrc to fix TLS handshake error especially noticed on `xoa.io`