### PR TITLE
Update .curlrc to fix TLS handshake

### DIFF
--- a/SOURCES/0009-fix-curl-resolve-TLS-issue-caused-by-restrictive-con.patch
+++ b/SOURCES/0009-fix-curl-resolve-TLS-issue-caused-by-restrictive-con.patch
@@ -1,0 +1,29 @@
+From 7414bb88e33064bf28629ee72c4dfa00a169ef93 Mon Sep 17 00:00:00 2001
+From: Lucas RAVAGNIER <ravagnierlucas@gmail.com>
+Date: Tue, 14 Jan 2025 16:15:29 +0100
+Subject: [PATCH 9/9] fix(curl): resolve TLS issue caused by restrictive
+ configuration
+
+Using a `.curlrc` file restricts the use of openssl encryption.
+This restriction blocks the ability to deploy an XOA because
+`xoa.io` website requires newer certificates.
+This patch therefore aims to add the same encryption from the xoa.io,
+making deployment easier for users while maintaining secure communications.
+
+Signed-off-by: Lucas RAVAGNIER <ravagnierlucas@gmail.com>
+---
+ src/common/root/.curlrc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/common/root/.curlrc b/src/common/root/.curlrc
+index c6113af..0726695 100644
+--- a/src/common/root/.curlrc
++++ b/src/common/root/.curlrc
+@@ -1,3 +1,3 @@
+ # See https://curl.haxx.se/docs/ssl-ciphers.html for the NSS names
+-ciphers = ecdhe_rsa_aes_256_sha_384,ecdhe_rsa_aes_256_gcm_sha_384,rsa_aes_256_cbc_sha_256,rsa_aes_128_cbc_sha_256
++ciphers = ecdhe_rsa_aes_256_sha_384,ecdhe_rsa_aes_256_gcm_sha_384,rsa_aes_256_cbc_sha_256,rsa_aes_128_cbc_sha_256,ECDHE-ECDSA-AES128-GCM-SHA256
+ tlsv1.2
+-- 
+2.47.0
+

--- a/SPECS/xcp-ng-release.spec
+++ b/SPECS/xcp-ng-release.spec
@@ -24,7 +24,7 @@
 
 Name:           xcp-ng-release
 Version:        8.2.1
-Release:        14
+Release:        15
 Summary:        XCP-ng release file
 Group:          System Environment/Base
 License:        GPLv2
@@ -102,6 +102,7 @@ Patch5: 0005-Update-xcp-ng.repo-for-the-new-repository-structure.patch
 Patch6: 0006-www-remove-quick-deploy-script-link-to-vates.tech-de.patch
 Patch7: 0007-Update-CentOS-and-EPEL-repo-files.patch
 Patch8: 0008-Sync-with-hotfix-XS82ECU1072.patch
+Patch9: 0009-fix-curl-resolve-TLS-issue-caused-by-restrictive-con.patch
 
 %description
 XCP-ng release files
@@ -816,6 +817,10 @@ systemctl preset-all --preset-mode=enable-only || :
 
 # Keep this changelog through future updates
 %changelog
+* Mon Jan 20 2025 Lucas Ravagnier <lucas.ravagnier@vates.tech> - 8.2.1-15
+- Add 0009-fix-curl-resolve-TLS-issue-caused-by-restrictive-con.patch
+- This adds a cipher to '.curlrc' to fix a TLS Handshake Error with xoa.io
+
 * Tue Nov 12 2024 Thierry Escande <thierry.escande@vates.tech> - 8.2.1-14
 - Sync with hotfix XS82ECU1072
 - *** Upstream changelog ***


### PR DESCRIPTION
Add a cipher in .curlrc to fix TLS handshake error especially noticed on `xoa.io`