### PR TITLE
Update .curlrc to fix TLS Handshake

### DIFF
--- a/SOURCES/0010-fix-curl-caused-by-incorrect-fix.patch
+++ b/SOURCES/0010-fix-curl-caused-by-incorrect-fix.patch
@@ -1,0 +1,21 @@
+From ecda3b09ab22e8b2bcd14204560f2b5975164e48 Mon Sep 17 00:00:00 2001
+From: rpm-build <rpm-build>
+Date: Fri, 21 Mar 2025 08:33:23 +0100
+Subject: [PATCH] fix
+
+---
+ src/common/root/.curlrc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/common/root/.curlrc b/src/common/root/.curlrc
+index 0726695..4c31e5f 100644
+--- a/src/common/root/.curlrc
++++ b/src/common/root/.curlrc
+@@ -1,3 +1,3 @@
+ # See https://curl.haxx.se/docs/ssl-ciphers.html for the NSS names
+-ciphers = ecdhe_rsa_aes_256_sha_384,ecdhe_rsa_aes_256_gcm_sha_384,rsa_aes_256_cbc_sha_256,rsa_aes_128_cbc_sha_256,ECDHE-ECDSA-AES128-GCM-SHA256
++ciphers = ECDHE-RSA-AES256-SHA384,ECDHE-RSA-AES256-GCM-SHA384,AES256-SHA256,AES128-SHA256,ECDHE-RSA-AES128-GCM-SHA256,ECDHE-ECDSA-AES128-GCM-SHA256
+ tlsv1.2
+-- 
+2.47.0
+

--- a/SPECS/xcp-ng-release.spec
+++ b/SPECS/xcp-ng-release.spec
@@ -24,7 +24,7 @@
 
 Name:           xcp-ng-release
 Version:        8.2.1
-Release:        15
+Release:        16
 Summary:        XCP-ng release file
 Group:          System Environment/Base
 License:        GPLv2
@@ -103,6 +103,7 @@ Patch6: 0006-www-remove-quick-deploy-script-link-to-vates.tech-de.patch
 Patch7: 0007-Update-CentOS-and-EPEL-repo-files.patch
 Patch8: 0008-Sync-with-hotfix-XS82ECU1072.patch
 Patch9: 0009-fix-curl-resolve-TLS-issue-caused-by-restrictive-con.patch
+Patch10: 0010-fix-curl-caused-by-incorrect-fix.patch
 
 %description
 XCP-ng release files
@@ -817,6 +818,10 @@ systemctl preset-all --preset-mode=enable-only || :
 
 # Keep this changelog through future updates
 %changelog
+* Fri Mar 21 2025 Lucas Ravagnier <lucas.ravagnier@vates.tech> - 8.2.1-16
+- Add 0010-fix-curl-caused-by-incorrect-fix.patch to fix previous patch (0009-fix-curl-resolve-TLS-issue-caused-by-restrictive-con.patch)
+- By adding a new cipher to '.curlrc' to fix a TLS handshake error with xoa.io this blocked the use of other ciphers
+
 * Mon Jan 20 2025 Lucas Ravagnier <lucas.ravagnier@vates.tech> - 8.2.1-15
 - Add 0009-fix-curl-resolve-TLS-issue-caused-by-restrictive-con.patch
 - This adds a cipher to '.curlrc' to fix a TLS Handshake Error with xoa.io


### PR DESCRIPTION
Added the same ciphers in 8.2 as in 8.3 See:
https://github.com/xcp-ng/xcp-ng-release/pull/49

Add a cipher in .curlrc to fix TLS handshake error especially noticed on `xoa.io`