### PR TITLE
Fix improperly generated patches

### DIFF
--- a/SOURCES/0001-fix-curl-resolve-TLS-issue-caused-by-restrictive-con.patch
+++ b/SOURCES/0001-fix-curl-resolve-TLS-issue-caused-by-restrictive-con.patch
@@ -1,7 +1,7 @@
 From e08c7d62ccf1acfedf0f227f1decd86110759c7d Mon Sep 17 00:00:00 2001
 From: Lucas RAVAGNIER <ravagnierlucas@gmail.com>
 Date: Tue, 14 Jan 2025 16:15:29 +0100
-Subject: [PATCH] fix(curl): resolve TLS issue caused by restrictive
+Subject: [PATCH 1/3] fix(curl): resolve TLS issue caused by restrictive
  configuration
 
 Using a `.curlrc` file restricts the use of openssl encryption.
@@ -24,5 +24,5 @@ index 46edee6..46ecb41 100644
 +ciphers = ECDHE-RSA-AES256-SHA384,ECDHE-RSA-AES256-GCM-SHA384,AES256-SHA256,AES128-SHA256,ECDHE-ECDSA-AES128-GCM-SHA256
  tlsv1.2
 -- 
-2.47.0
+2.49.0
 

--- a/SOURCES/0002-Sync-vm.slice-with-xenserver-release-v8.4.0-12.tar.g.patch
+++ b/SOURCES/0002-Sync-vm.slice-with-xenserver-release-v8.4.0-12.tar.g.patch
@@ -1,7 +1,7 @@
 From a0ad0bb5158e491a577c3fa0f0522fefc14e9f80 Mon Sep 17 00:00:00 2001
 From: XenServer <xenserver@cloud.com>
 Date: Fri, 20 Sep 2024 16:41:00 +0000
-Subject: [PATCH 1/2] Sync vm.slice with xenserver-release-v8.4.0-12.tar.gz
+Subject: [PATCH 2/3] Sync vm.slice with xenserver-release-v8.4.0-12.tar.gz
 
   * Fri Sep 20 2024 Mark Syms <mark.syms@cloud.com> - 8.4.0-12
   - CA-399511: Change systemd dependencies for vm.slice
@@ -27,5 +27,5 @@ index a5792eb..edf4cc2 100644
 -WantedBy=multi-user.target
 +RequiredBy=multi-user.target
 -- 
-2.39.5
+2.49.0
 

--- a/SOURCES/0003-Sync-systemd-presets-with-xenserver-release-v8.4.0-1.patch
+++ b/SOURCES/0003-Sync-systemd-presets-with-xenserver-release-v8.4.0-1.patch
@@ -1,7 +1,7 @@
 From 287d3486a319df72c8dc908c439183eb5385dc4d Mon Sep 17 00:00:00 2001
 From: XenServer <xenserver@cloud.com>
 Date: Tue, 1 Oct 2024 15:00:00 +0000
-Subject: [PATCH 2/2] Sync systemd presets with
+Subject: [PATCH 3/3] Sync systemd presets with
  xenserver-release-v8.4.0-13.tar.gz
 
   * Fri Oct 04 2024 Ross Lagerwall <ross.lagerwall@citrix.com> - 8.4.0-13
@@ -27,5 +27,5 @@ index 1839c39..e1dfaf6 100644
  enable varstored-guard.service
  enable secureboot-certificates.service
 -- 
-2.39.5
+2.49.0
 

--- a/SPECS/xcp-ng-release.spec
+++ b/SPECS/xcp-ng-release.spec
@@ -45,7 +45,7 @@
 
 Name:           xcp-ng-release
 Version:        8.3.0
-Release:        31
+Release:        32
 Summary:        XCP-ng release file
 Group:          System Environment/Base
 License:        GPLv2
@@ -106,8 +106,10 @@ URL:            https://github.com/xcp-ng/xcp-ng-release
 # export VER=8.3.0; git archive --format tgz master . --prefix xcp-ng-release-$VER/ -o /path/to/SOURCES/xcp-ng-release-$VER.tar.gz
 Source0:        https://github.com/xcp-ng/xcp-ng-release/archive/v%{version}/xcp-ng-release-%{version}.tar.gz
 
-# XCP-ng Patches generated during maintenance period with `git format-patch v8.3`
-Patch1000: 0001-fix-curl-resolve-TLS-issue-caused-by-restrictive-con.patch
+# XCP-ng Patches generated during maintenance period with `git format-patch v8.3.0`
+Patch1001: 0001-fix-curl-resolve-TLS-issue-caused-by-restrictive-con.patch
+Patch1002: 0002-Sync-vm.slice-with-xenserver-release-v8.4.0-12.tar.g.patch
+Patch1003: 0003-Sync-systemd-presets-with-xenserver-release-v8.4.0-1.patch
 
 %description
 XCP-ng release files
@@ -613,6 +615,11 @@ systemctl preset-all --preset-mode=enable-only || :
 
 # Keep this changelog through future updates
 %changelog
+* Thu May 08 2025 Andrii Sultanov <andriy.sultanov@vates.tech> - 8.3.0-32
+- Fix patches that weren't properly generated and included in the specfile:
+  - 0002-Sync-vm.slice-with-xenserver-release-v8.4.0-12.tar.g.patch
+  - 0003-Sync-systemd-presets-with-xenserver-release-v8.4.0-1.patch
+
 * Thu Apr 03 2025 Samuel Verschelde <stormi-xcp@ylix.fr> - 8.3.0-31
 - Rebuild for updated branding-xcp-ng
 - Loosely sync with xenserver-release-8.4.0-15 (no real change, just a merge point)


### PR DESCRIPTION
Patches `Sync-vm.slice-with-xenserver-release-v8.4.0-12.tar.g.patch` and `Sync-systemd-presets-with-xenserver-release-v8.4.0-1.patch` were not generated correctly and were not included in the spec file. Regenerate all three current patches and update the command noted in the specfile used to generate them.