### PR TITLE
Koji/test/GitHub pull34/2025 11 07 14 56 08

### DIFF
--- a/SOURCES/0001-fix-curl-resolve-TLS-issue-caused-by-restrictive-con.patch
+++ b/SOURCES/0001-fix-curl-resolve-TLS-issue-caused-by-restrictive-con.patch
@@ -1,7 +1,7 @@
 From e08c7d62ccf1acfedf0f227f1decd86110759c7d Mon Sep 17 00:00:00 2001
 From: Lucas RAVAGNIER <ravagnierlucas@gmail.com>
 Date: Tue, 14 Jan 2025 16:15:29 +0100
-Subject: [PATCH 1/3] fix(curl): resolve TLS issue caused by restrictive
+Subject: [PATCH] fix(curl): resolve TLS issue caused by restrictive
  configuration
 
 Using a `.curlrc` file restricts the use of openssl encryption.
@@ -24,5 +24,5 @@ index 46edee6..46ecb41 100644
 +ciphers = ECDHE-RSA-AES256-SHA384,ECDHE-RSA-AES256-GCM-SHA384,AES256-SHA256,AES128-SHA256,ECDHE-ECDSA-AES128-GCM-SHA256
  tlsv1.2
 -- 
-2.49.0
+2.51.1
 

--- a/SOURCES/0002-Sync-vm.slice-with-xenserver-release-v8.4.0-12.tar.g.patch
+++ b/SOURCES/0002-Sync-vm.slice-with-xenserver-release-v8.4.0-12.tar.g.patch
@@ -1,7 +1,7 @@
 From a0ad0bb5158e491a577c3fa0f0522fefc14e9f80 Mon Sep 17 00:00:00 2001
 From: XenServer <xenserver@cloud.com>
 Date: Fri, 20 Sep 2024 16:41:00 +0000
-Subject: [PATCH 2/3] Sync vm.slice with xenserver-release-v8.4.0-12.tar.gz
+Subject: [PATCH] Sync vm.slice with xenserver-release-v8.4.0-12.tar.gz
 
   * Fri Sep 20 2024 Mark Syms <mark.syms@cloud.com> - 8.4.0-12
   - CA-399511: Change systemd dependencies for vm.slice
@@ -27,5 +27,5 @@ index a5792eb..edf4cc2 100644
 -WantedBy=multi-user.target
 +RequiredBy=multi-user.target
 -- 
-2.49.0
+2.51.1
 

--- a/SOURCES/0003-Sync-systemd-presets-with-xenserver-release-v8.4.0-1.patch
+++ b/SOURCES/0003-Sync-systemd-presets-with-xenserver-release-v8.4.0-1.patch
@@ -1,8 +1,7 @@
 From 287d3486a319df72c8dc908c439183eb5385dc4d Mon Sep 17 00:00:00 2001
 From: XenServer <xenserver@cloud.com>
 Date: Tue, 1 Oct 2024 15:00:00 +0000
-Subject: [PATCH 3/3] Sync systemd presets with
- xenserver-release-v8.4.0-13.tar.gz
+Subject: [PATCH] Sync systemd presets with xenserver-release-v8.4.0-13.tar.gz
 
   * Fri Oct 04 2024 Ross Lagerwall <ross.lagerwall@citrix.com> - 8.4.0-13
   - Enable new RRDD plugins
@@ -27,5 +26,5 @@ index 1839c39..e1dfaf6 100644
  enable varstored-guard.service
  enable secureboot-certificates.service
 -- 
-2.49.0
+2.51.1
 

--- a/SPECS/xcp-ng-release.spec
+++ b/SPECS/xcp-ng-release.spec
@@ -106,7 +106,7 @@ URL:            https://github.com/xcp-ng/xcp-ng-release
 # export VER=8.3.0; git archive --format tgz master . --prefix xcp-ng-release-$VER/ -o /path/to/SOURCES/xcp-ng-release-$VER.tar.gz
 Source0:        https://github.com/xcp-ng/xcp-ng-release/archive/v%{version}/xcp-ng-release-%{version}.tar.gz
 
-# XCP-ng Patches generated during maintenance period with `git format-patch v8.3.0`
+# XCP-ng Patches generated during maintenance period with `git format-patch --no-numbered v8.3.0`
 Patch1001: 0001-fix-curl-resolve-TLS-issue-caused-by-restrictive-con.patch
 Patch1002: 0002-Sync-vm.slice-with-xenserver-release-v8.4.0-12.tar.g.patch
 Patch1003: 0003-Sync-systemd-presets-with-xenserver-release-v8.4.0-1.patch

--- a/SPECS/xcp-ng-release.spec
+++ b/SPECS/xcp-ng-release.spec
@@ -45,7 +45,7 @@
 
 Name:           xcp-ng-release
 Version:        8.3.0
-Release:        33
+Release:        33~GithubPull34.1
 Summary:        XCP-ng release file
 Group:          System Environment/Base
 License:        GPLv2

--- a/SPECS/xcp-ng-release.spec
+++ b/SPECS/xcp-ng-release.spec
@@ -45,7 +45,7 @@
 
 Name:           xcp-ng-release
 Version:        8.3.0
-Release:        32
+Release:        33
 Summary:        XCP-ng release file
 Group:          System Environment/Base
 License:        GPLv2
@@ -615,6 +615,10 @@ systemctl preset-all --preset-mode=enable-only || :
 
 # Keep this changelog through future updates
 %changelog
+* Fri Nov 7 2025 Philippe Coval <philippe.coval@vates.tech> - 8.3.0-33
+- chore(spec): Update procedure for git-format-patch --no-numbered
+- chore(patches): Regen patches without numbered subject
+
 * Thu May 08 2025 Andrii Sultanov <andriy.sultanov@vates.tech> - 8.3.0-32
 - Fix patches that weren't properly generated and included in the specfile:
   - 0002-Sync-vm.slice-with-xenserver-release-v8.4.0-12.tar.g.patch


### PR DESCRIPTION
# notice: 

Do not use --pre-build but --scratch

# Context

Please ignore this PR,  I am considering to close it after 34 merge

It contains changes from this PR (please review):

https://github.com/xcp-ng-rpms/xcp-ng-release/pull/34

And koji generated 2415833ffd0e7925131ca26c4838a20ed9d34191 which we dont want in (and it does not have signed-off git footer)

For the record this PR was created using koji_build.py  from https://github.com/xcp-ng/xcp

```
feature=GithubPull34 # Better use a real ticket id
xcp-ng-release-rpm # $ koji_build.py --pre-build $feature v8.3-incoming .
From git@github.com:/xcp-ng-rpms/xcp-ng-release
(...)
remote: Create a pull request for 'koji/test/GithubPull34/2025-11-07-14-56-08' on GitHub by visiting:
remote:      https://github.com/xcp-ng-rpms/xcp-ng-release/pull/new/koji/test/GithubPull34/2025-11-07-14-56-08
(...)
koji  build  --wait-repo  v8.3-incoming  git+https://github.com//xcp-ng-rpms/xcp-ng-release?#2415833ffd0e7925131ca26c4838a20ed9d34191
(...)
92162 build (v8.3-incoming, //xcp-ng-rpms/xcp-ng-release:2415833ffd0e7925131ca26c4838a20ed9d34191) completed successfully
```

Outputs are available from:

- https://koji.xcp-ng.org/buildinfo?buildID=4164
  - https://koji.xcp-ng.org/kojifiles/packages/xcp-ng-release/8.3.0/33~GithubPull34.1/src/xcp-ng-release-8.3.0-33~GithubPull34.1.src.rpm
  