### PR TITLE
Add timestamps to history (and regen patch queue to align)

### DIFF
--- a/SOURCES/0004-fix-prompt-s-c-e-p-xcp-ng-prompt.sh-Fix-prompt-on-te.patch
+++ b/SOURCES/0004-fix-prompt-s-c-e-p-xcp-ng-prompt.sh-Fix-prompt-on-te.patch
@@ -1,17 +1,26 @@
-From 1762faf8c6876c89f961e53457d2040b56b105bf Mon Sep 17 00:00:00 2001
+From 082e270b803bd712b75c6554940af9344f645815 Mon Sep 17 00:00:00 2001
 From: Philippe Coval <philippe.coval@vates.tech>
 Date: Thu, 6 Nov 2025 10:08:27 +0100
-Subject: [PATCH] s/s/c/e/p/xcp-ng-prompt.sh: Fix prompt on testing tput output
+Subject: [PATCH] fix(prompt): s/c/e/p/xcp-ng-prompt.sh: Fix prompt on testing
+ tput output
 
 Harden the prompt test, in case tput is failing or output is null.
 
+For the record this issue can be reproduced when passing an undeclared TERM
+
+   TERM=''  ssh $host
+   -bash: [: -ge: unary operator expected
+   [13:53 xcp-ng-pcl-11 ~]# echo $PS1
+   [\A \h \W]\$
+
+Relate-to: https://github.com/xcp-ng/xcp/issues/682
 Signed-off-by: Philippe Coval <philippe.coval@vates.tech>
 ---
  src/common/etc/profile.d/xcp-ng-prompt.sh | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/common/etc/profile.d/xcp-ng-prompt.sh b/src/common/etc/profile.d/xcp-ng-prompt.sh
-index 98fcc4b..a7ed2af 100644
+index 98fcc4b..a298a56 100644
 --- a/src/common/etc/profile.d/xcp-ng-prompt.sh
 +++ b/src/common/etc/profile.d/xcp-ng-prompt.sh
 @@ -3,7 +3,7 @@
@@ -19,7 +28,7 @@ index 98fcc4b..a7ed2af 100644
  
  # BASH : Configure things differently if current terminal has >= 8 colors.
 -if [ "$PS1" ] && [ $(tput colors 2>/dev/null) -ge 8 ]; then
-+if [ "$PS1" ] && [ "$(tput colors 2>/dev/null || printf 0)" -ge 8 ]; then
++if [ "$PS1" ] && [ "$(tput colors 2>/dev/null || echo 0)" -ge 8 ]; then
      PS1='\[\e[0;38;5;160m\][\[\e[0;2m\]\A \[\e[0;1;38;5;105m\]\h \[\e[0m\]\W\[\e[0;38;5;160m\]]\[\e[0m\]\$ '
  else
      PS1='[\A \h \W]\$ '

--- a/SOURCES/0005-s-c-e-profile.d-history.sh-Add-timestamps-to-history.patch
+++ b/SOURCES/0005-s-c-e-profile.d-history.sh-Add-timestamps-to-history.patch
@@ -1,0 +1,28 @@
+From abdf03db214224f907515c3309634a3b13cdc605 Mon Sep 17 00:00:00 2001
+From: Philippe Coval <philippe.coval@vates.tech>
+Date: Mon, 15 Dec 2025 11:26:31 +0100
+Subject: [PATCH] s/c/e/profile.d/history.sh: Add timestamps to history
+
+... using HISTTIMEFORMAT
+
+The ISO prefix is used because easier to read/parse and less prone to
+ambuiguity (EU vs US).
+
+The file structure is aligned to xs.sh
+
+Signed-off-by: Philippe Coval <philippe.coval@vates.tech>
+---
+ src/common/etc/profile.d/history.sh | 4 ++++
+ 1 file changed, 4 insertions(+)
+ create mode 100644 src/common/etc/profile.d/history.sh
+
+diff --git a/src/common/etc/profile.d/history.sh b/src/common/etc/profile.d/history.sh
+new file mode 100644
+index 0000000..999c80a
+--- /dev/null
++++ b/src/common/etc/profile.d/history.sh
+@@ -0,0 +1,4 @@
++#!/bin/sh
++
++HISTTIMEFORMAT="%Y-%m-%d %T "
++export HISTTIMEFORMAT

--- a/SOURCES/0006-fix-prompt-s-c-e-p-xcp-ng-prompt.sh-Align-to-RPM-pat.patch
+++ b/SOURCES/0006-fix-prompt-s-c-e-p-xcp-ng-prompt.sh-Align-to-RPM-pat.patch
@@ -1,0 +1,38 @@
+From 8a4015ac1aefff5ed452bfd0c2789965eef99918 Mon Sep 17 00:00:00 2001
+From: Philippe Coval <philippe.coval@vates.tech>
+Date: Tue, 6 Jan 2026 10:26:46 +0100
+Subject: [PATCH] fix(prompt): s/c/e/p/xcp-ng-prompt.sh: Align to RPM patch
+
+The patch released in RPM differs than the reviewed one
+(I wrongly using my fork as origin and not upstream)
+
+This change is an adaptation of:
+
+xcp-ng-release-rpm/SOURCES/0004-s-s-c-e-p-xcp-ng-prompt.sh-Fix-prompt-on-testing-tpu.patch
+
+There are some advantages of using printf over echo:
+
+https://unix.stackexchange.com/questions/65803/why-is-printf-better-than-echo/65819#65819
+
+Anyway the impact is null, but this will make the export patch queue
+more consistant.
+
+Relate-to: https://github.com/xcp-ng-rpms/xcp-ng-release/commit/56f7e57d1662dc71f2a368b57fd61a010fccf795#r173966316
+Signed-off-by: Philippe Coval <philippe.coval@vates.tech>
+---
+ src/common/etc/profile.d/xcp-ng-prompt.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/common/etc/profile.d/xcp-ng-prompt.sh b/src/common/etc/profile.d/xcp-ng-prompt.sh
+index a298a56..a7ed2af 100644
+--- a/src/common/etc/profile.d/xcp-ng-prompt.sh
++++ b/src/common/etc/profile.d/xcp-ng-prompt.sh
+@@ -3,7 +3,7 @@
+ ########################################
+ 
+ # BASH : Configure things differently if current terminal has >= 8 colors.
+-if [ "$PS1" ] && [ "$(tput colors 2>/dev/null || echo 0)" -ge 8 ]; then
++if [ "$PS1" ] && [ "$(tput colors 2>/dev/null || printf 0)" -ge 8 ]; then
+     PS1='\[\e[0;38;5;160m\][\[\e[0;2m\]\A \[\e[0;1;38;5;105m\]\h \[\e[0m\]\W\[\e[0;38;5;160m\]]\[\e[0m\]\$ '
+ else
+     PS1='[\A \h \W]\$ '

--- a/SPECS/xcp-ng-release.spec
+++ b/SPECS/xcp-ng-release.spec
@@ -45,7 +45,7 @@
 
 Name:           xcp-ng-release
 Version:        8.3.0
-Release:        36
+Release:        37
 Summary:        XCP-ng release file
 Group:          System Environment/Base
 License:        GPLv2
@@ -110,7 +110,9 @@ Source0:        https://github.com/xcp-ng/xcp-ng-release/archive/v%{version}/xcp
 Patch1001: 0001-fix-curl-resolve-TLS-issue-caused-by-restrictive-con.patch
 Patch1002: 0002-Sync-vm.slice-with-xenserver-release-v8.4.0-12.tar.g.patch
 Patch1003: 0003-Sync-systemd-presets-with-xenserver-release-v8.4.0-1.patch
-Patch1004: 0004-s-s-c-e-p-xcp-ng-prompt.sh-Fix-prompt-on-testing-tpu.patch
+Patch1004: 0004-fix-prompt-s-c-e-p-xcp-ng-prompt.sh-Fix-prompt-on-te.patch
+Patch1005: 0005-s-c-e-profile.d-history.sh-Add-timestamps-to-history.patch
+Patch1006: 0006-fix-prompt-s-c-e-p-xcp-ng-prompt.sh-Align-to-RPM-pat.patch
 
 %description
 XCP-ng release files
@@ -616,6 +618,10 @@ systemctl preset-all --preset-mode=enable-only || :
 
 # Keep this changelog through future updates
 %changelog
+* Sun Feb 22 2026 Philippe Coval <philippe.coval@vates.tech> - 8.3.0-37
+- Realign upstream to prompt patch from RPM
+- Add timestamps to history
+
 * Mon Jan 26 2026 Philippe Coval <philippe.coval@vates.tech> - 8.3.0-36
 - Preserve /etc/rsyslog.d/xenserver.conf if present
 


### PR DESCRIPTION
Add timestamps to history 

The prompt patches are caused by a missalignement on a single patch, which has been fixed by realigning upstream to rpm patch, this cause an extra "fixup" patch in the queue.

Relate-to: https://github.com/xcp-ng/xcp-ng-release/pull/54
Relate-to: https://github.com/xcp-ng-rpms/xcp-ng-release/commit/56f7e57d1662dc71f2a368b57fd61a010fccf795#r173966316


- [x] Koji build Scratch (v8.3-incoming): https://koji.xcp-ng.org/taskinfo?taskID=93977
