### PR TITLE
Set gnutls-dane obsolete

### DIFF
--- a/SPECS/xcp-ng-release.spec
+++ b/SPECS/xcp-ng-release.spec
@@ -87,6 +87,9 @@ Obsoletes:      update-XS81E003 control-XS81E003
 Obsoletes:      update-XS81E004 control-XS81E004
 Obsoletes:      update-XS81E005 control-XS81E005
 
+#Obsolete: Obsolete unused packages for OpenSSL 3 upgrade
+Obsoletes: gnutls-dane <= 3.3.29-9.el7_6
+
 # Metadata for the installer to consume
 Provides:       product-brand = XCP-ng
 Provides:       product-version = %{PRODUCT_VERSION}


### PR DESCRIPTION
This is need to update gnutls.

Relate-to: xs-obsolete-packages-8-17.xs8.src.rpm


- [ ] Confirm motivation
- [x] Koji pre-build XCPNG2710 (v8.3-u-pcoval2): https://koji.xcp-ng.org/taskinfo?taskID=94631
- [ ] Update changelog (matching merge date ?)
